### PR TITLE
FIX: Delegation changes to resolve memory issue

### DIFF
--- a/Source/BrightnessView.swift
+++ b/Source/BrightnessView.swift
@@ -7,10 +7,14 @@
 
 import UIKit
 
-class BrightnessView: UIView {
-    
-    var delegate: SwiftHSVColorPicker?
+protocol BrightnessViewDelegate: class {
+   func brightnessSelected(brightness: CGFloat)
+}
 
+class BrightnessView: UIView {
+  
+    weak var delegate: BrightnessViewDelegate?
+  
     var colorLayer: CAGradientLayer!
     
     var point: CGPoint!

--- a/Source/ColorWheel.swift
+++ b/Source/ColorWheel.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol ColorWheelDelegate: class {
+    func hueAndSaturationSelected(hue: CGFloat, saturation: CGFloat)
+}
+
 class ColorWheel: UIView {
     var color: UIColor!
 
@@ -27,8 +31,8 @@ class ColorWheel: UIView {
     // Retina scaling factor
     let scale: CGFloat = UIScreen.mainScreen().scale
     
-    var delegate: SwiftHSVColorPicker?
-    
+    weak var delegate: ColorWheelDelegate?
+  
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder);
     }

--- a/Source/SwiftHSVColorPicker.swift
+++ b/Source/SwiftHSVColorPicker.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public class SwiftHSVColorPicker: UIView {
+public class SwiftHSVColorPicker: UIView, ColorWheelDelegate, BrightnessViewDelegate {
     var colorWheel: ColorWheel!
     var brightnessView: BrightnessView!
     var selectedColorView: SelectedColorView!


### PR DESCRIPTION
See [colorPickerRetainCycleDemo](https://github.com/spacedrabbit/colorPickerRetainCycleDemo) for a simple demo to reproduce the problem encountered and test the proposed change.

First all, thank you for putting together this pod. It was exactly what I was looking for for a small project of mine. 

---

This proposal is a minimally invasive change to the library that prevents a cyclical strong reference between the `SwiftHSVColorPicker` and two of the views it owned, `ColorWheel` and `BrightnessView`, which also strongly reference back to their owning `SwiftHSVColorPicker` instance.

It swaps out a strong reference in both cases with a `weak`ly paired delegate based on two simple protocols (`BrightnessViewDelegate` and  `ColorWheelDelegate`) that make use of already existing functions in `SwiftHSVColorPicker` (`hueAndSaturationSelected(_:saturation:)` and `brightnessSelected(_:)`). 

The demo repo README goes into a little bit more detail.
### Before:

![Current library, TableVC](http://i.imgur.com/1zCKjzv.png)
### After:

![Delegation changes applied, TableVC](http://i.imgur.com/EiVkpgx.png)
